### PR TITLE
Make parameters optional (typescript)

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,7 +22,7 @@ type Result = {
 };
 
 /** Looks for the nearest parent package.json. */
-const parentPackageJSON = (params: Parameters | undefined): Result => {
+const parentPackageJSON = (params?: Parameters): Result => {
 	const startPath = params?.startPath ?? process.cwd();
 	const ignoreCount = params?.ignoreCount ?? 0;
 


### PR DESCRIPTION
Typescript requires passing `undefined` when not passing parameters.